### PR TITLE
feat: add batch requirements to generateRows

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,16 @@ matrix.addAxis({
 matrix.setNamePattern(['os', 'tz', 'locale']);
 
 matrix.exclude({locale: {language: 'de'}, os: 'macos-latest'});
-matrix.generateRow({os: 'windows-latest'});
-matrix.generateRow({os: 'ubuntu-latest'});
 
-const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 5));
+// Pass the combinations you care about as a batch. generateRows guarantees a row
+// for each one, fixes the job count regardless of list order, and fills the rest
+// of the budget with pairwise coverage.
+const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 5), {
+  require: [
+    ...matrix.allAxisValues('os'), // run every OS at least once
+    {tz: 'UTC'},
+  ],
+});
 if (include.length === 0) {
   throw new Error('Matrix list is empty');
 }
@@ -109,13 +115,45 @@ API
 
 Features:
 
+* `generateRows(n, {require})` is the main entry point: it generates the combinations you require as a batch and packs them into a fixed job count, independent of list order
+* `allAxisValues(axis)` expands an axis into a `require` list, so every value runs at least once
 * Randomized pairwise coverage keeps CI job counts low while exploring more combinations
 * `exclude(...)` forbids invalid combinations
 * `imply(...)` models rules like `windows -> jdk 17`
 * `constrain(...)` supports custom predicates across multiple axes
-* `generateRow(...)` forces important rows to appear
-* `ensureAllAxisValuesCovered(...)` guarantees each value of an axis appears at least once
 * `pairCoverageReport()` reports feasible pair coverage
+* `generateRow(...)` and `ensureAllAxisValuesCovered(...)` force individual rows imperatively, for the rare cases in [Forcing individual rows](#forcing-individual-rows)
+
+Batch requirements
+------------------
+
+`generateRows(n, {require: [...]})` is the main way to drive the matrix. It guarantees a row for each required combination, packs them into as few rows as possible, and spends the rest of the `n`-row budget on pairwise coverage. The job count is `n`, and the result does not depend on the order of the list.
+
+A `require` entry is either a filter or a `{filter, tag}` pair. `tag(row)` runs with the row that satisfies the requirement, so you can mark a job without searching the result again. For example, to collect code coverage on a single job pinned to a specific combination:
+
+```js
+const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 5), {
+  require: [
+    {filter: {os: 'ubuntu-latest', pg_version: '18', ssl: 'yes', scram: 'yes'},
+     tag: row => { row.collectCoverage = true; }},
+    {query_mode: 'simple'},
+    ...matrix.allAxisValues('ssl'),
+    ...matrix.allAxisValues('gss'),
+  ],
+});
+```
+
+When a requirement cannot fit the budget, or is unsatisfiable, `generateRows` warns. Call `failOnUnsatisfiableFilters(true)` to turn that into an error.
+
+Forcing individual rows
+-----------------------
+
+Before batch requirements the matrix was driven one row at a time. These calls remain for the rare cases that still want them:
+
+* `generateRow(filter)` adds a single row and returns it (or an existing match), so you can keep a handle and set fields on it. The `tag` callback above covers most of this; reach for `generateRow` for a one-off you inspect locally.
+* `ensureAllAxisValuesCovered(axis)` is the imperative form of spreading `...matrix.allAxisValues(axis)` into a `require` list.
+
+Prefer `generateRows({require})`. A sequence of imperative calls makes both the job count and the coverage depend on call order, because a row generated for an early filter may satisfy a later one by chance.
 
 Sample integrations
 -------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vlsi/github-actions-random-matrix",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Pairwise test matrix generator with constraint support and GitHub Actions integration",
   "type": "module",
   "main": "./src/matrix_builder.mjs",

--- a/src/matrix_builder.mjs
+++ b/src/matrix_builder.mjs
@@ -291,16 +291,17 @@ class MatrixBuilder {
    * @param filter object with keys matching axes names
    * @returns {*}
    */
-  generateRow(filter, {warnOnFailure = true} = {}) {
-    this._initPairs();
-    if (filter) {
-      // If matching row already exists, no need to generate more
-      const existing = this.rows.find(v => Axis.matches(v, filter));
-      if (existing) {
-        return existing;
-      }
-    }
-
+  /**
+   * Generates many random candidates matching `filter`, scores each by the
+   * weighted number of new pairs it would cover (plus an optional `bonus`), and
+   * commits the best-scoring one to the matrix. Returns the committed row, or
+   * null if no valid candidate could be produced.
+   *
+   * `bonus(candidate)` lets callers add to the base pair-coverage score, e.g. to
+   * reward rows that also satisfy still-open batch requirements (see
+   * {@link generateRows}).
+   */
+  _addBestRow(filter, bonus) {
     const numCandidates = 1000;
     let bestRow = null;
     let bestScore = -1;
@@ -314,20 +315,40 @@ class MatrixBuilder {
       const key = JSON.stringify(candidate);
       if (this.duplicates.hasOwnProperty(key)) continue;
 
-      const score = this._scoreNewPairs(candidate);
+      let score = this._scoreNewPairs(candidate);
+      if (bonus) {
+        score += bonus(candidate);
+      }
       if (score > bestScore) {
         bestScore = score;
         bestRow = candidate;
       }
     }
 
-    if (bestRow) {
-      const key = JSON.stringify(bestRow);
-      this.duplicates[key] = true;
-      bestRow.name = this._computeName(bestRow);
-      this._markCovered(bestRow);
-      this.rows.push(bestRow);
-      return bestRow;
+    if (!bestRow) {
+      return null;
+    }
+    const key = JSON.stringify(bestRow);
+    this.duplicates[key] = true;
+    bestRow.name = this._computeName(bestRow);
+    this._markCovered(bestRow);
+    this.rows.push(bestRow);
+    return bestRow;
+  }
+
+  generateRow(filter, {warnOnFailure = true} = {}) {
+    this._initPairs();
+    if (filter) {
+      // If matching row already exists, no need to generate more
+      const existing = this.rows.find(v => Axis.matches(v, filter));
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const row = this._addBestRow(filter, null);
+    if (row) {
+      return row;
     }
 
     const filterStr = typeof filter === 'string' ? filter.toString() : JSON.stringify(filter);
@@ -345,14 +366,156 @@ class MatrixBuilder {
     }
   }
 
-  generateRows(maxRows, filter) {
+  /**
+   * Returns a filter for every value of an axis, as a list suitable for the
+   * `require` option of {@link generateRows}. For example,
+   * `allAxisValues('ssl')` returns `[{ssl: <value0>}, {ssl: <value1>}, ...]`,
+   * the batch equivalent of {@link ensureAllAxisValuesCovered}.
+   */
+  allAxisValues(axisName) {
+    return this.axisByName[axisName].values.map(value => ({[axisName]: value}));
+  }
+
+  /**
+   * Normalizes `require` entries to `{filter, tag}`. A bare filter object stays
+   * a filter; a `{filter, tag}` wrapper is passed through.
+   */
+  _normalizeRequirements(specs) {
+    return specs.map(spec => {
+      if (spec && typeof spec === 'object' && !Array.isArray(spec)
+          && ('filter' in spec || 'tag' in spec)) {
+        return {filter: spec.filter, tag: spec.tag};
+      }
+      return {filter: spec, tag: undefined};
+    });
+  }
+
+  /**
+   * Number of axes a requirement filter pins. More pinned axes => more specific,
+   * so it should anchor its own row rather than hope to be covered incidentally.
+   */
+  _filterKeyCount(filter) {
+    return filter && typeof filter === 'object' && !Array.isArray(filter)
+      ? Object.keys(filter).length
+      : 1;
+  }
+
+  /**
+   * Removes from `pending` every requirement that some existing row already
+   * satisfies, firing its `tag(row)` callback once. Mutates `pending`.
+   */
+  _resolveSatisfied(pending) {
+    for (let k = pending.length - 1; k >= 0; k--) {
+      const req = pending[k];
+      const row = this.rows.find(r => Axis.matches(r, req.filter));
+      if (row) {
+        if (req.tag) {
+          req.tag(row);
+        }
+        pending.splice(k, 1);
+      }
+    }
+  }
+
+  /**
+   * Generates rows until `maxRows` is reached.
+   *
+   * With no options (or a legacy filter object) this is the original pairwise
+   * fill: each new row maximizes uncovered-pair coverage.
+   *
+   * With `{require: [...]}` the listed combinations become a batch of hard
+   * requirements. The result is guaranteed to contain a row matching each one
+   * (subject to feasibility and the `maxRows` budget), and rows are chosen
+   * jointly: a single row covers as many still-open requirements as it can
+   * before the leftover budget is spent on plain pairwise coverage. Unlike
+   * calling generateRow() once per requirement, the outcome does not depend on
+   * the order of the list, and the job count is `maxRows`, not an emergent
+   * function of that order.
+   *
+   * Each `require` entry is either a filter (`{ssl: {value: 'yes'}}`) or a
+   * `{filter, tag}` object whose `tag(row)` is called with the row that ends up
+   * satisfying it — handy for marking a specific job without searching the
+   * result again, e.g. a single coverage job:
+   *   {filter: {os: {value: 'ubuntu-latest'}, ...}, tag: r => r.collectCoverage = true}
+   *
+   * Rows generated earlier (e.g. a pinned row from generateRow()) count toward
+   * both the budget and requirement satisfaction.
+   *
+   * @param {number} maxRows
+   * @param {object} [options] `{require, fill}`, or a legacy fill filter
+   * @returns {Array} the generated rows
+   */
+  generateRows(maxRows, options) {
     this._initPairs();
+
+    let requireSpecs = [];
+    let fillFilter;
+    if (options && (options.require || options.fill)) {
+      requireSpecs = options.require || [];
+      fillFilter = options.fill;
+    } else {
+      // Backward compatible: generateRows(maxRows[, filter])
+      fillFilter = options;
+    }
+
+    const pending = this._normalizeRequirements(requireSpecs);
+    const infeasible = [];
+
+    // Pinned / pre-existing rows may already satisfy some requirements.
+    this._resolveSatisfied(pending);
+
+    // A satisfied requirement must outweigh any pair-coverage delta, so packing
+    // requirements into as few rows as possible always wins; ties break on
+    // coverage. This frees the most budget for the plain-coverage fill below.
+    const BONUS = 1000;
+    const requirementBonus = candidate => {
+      let n = 0;
+      for (const req of pending) {
+        if (Axis.matches(candidate, req.filter)) {
+          n++;
+        }
+      }
+      return n * BONUS;
+    };
+
+    // Phase 1: satisfy requirements. Anchor each row on the most specific open
+    // requirement (most pinned axes); the bonus packs the broad ones onto it.
+    while (this.rows.length < maxRows && pending.length > 0) {
+      const anchor = pending.reduce((a, b) =>
+        this._filterKeyCount(b.filter) > this._filterKeyCount(a.filter) ? b : a);
+      const row = this._addBestRow(anchor.filter, requirementBonus);
+      if (!row) {
+        infeasible.push(anchor);
+        pending.splice(pending.indexOf(anchor), 1);
+        continue;
+      }
+      this._resolveSatisfied(pending);
+    }
+
+    // Phase 2: spend the remaining budget on plain pairwise coverage.
     for (let i = 0; this.rows.length < maxRows && i < maxRows; i++) {
-      const row = this.generateRow(filter, {warnOnFailure: false});
+      const row = this.generateRow(fillFilter, {warnOnFailure: false});
       if (!row) {
         break;
       }
     }
+
+    const problems = [];
+    if (infeasible.length > 0) {
+      problems.push(`unsatisfiable: ${infeasible.map(r => JSON.stringify(r.filter)).join(', ')}`);
+    }
+    if (pending.length > 0) {
+      problems.push(`did not fit into ${maxRows} rows: ${pending.map(r => JSON.stringify(r.filter)).join(', ')}`);
+    }
+    if (problems.length > 0) {
+      const msg = `generateRows could not satisfy all requirements (${problems.join('; ')})`;
+      if (this._failOnUnsatisfiableFilters) {
+        throw Error(msg);
+      } else {
+        console.warn(msg);
+      }
+    }
+
     return this.rows;
   }
 

--- a/test/matrix_builder.test.mjs
+++ b/test/matrix_builder.test.mjs
@@ -230,6 +230,128 @@ describe('generateRows', () => {
   });
 });
 
+describe('generateRows with batch requirements', () => {
+  it('satisfies every required combination within the budget', () => {
+    const m = buildSimpleMatrix(createTestRng());
+    m.generateRows(6, {
+      require: [
+        {os: 'windows'},
+        {os: 'mac'},
+        {jdk: '8'},
+        {jdk: '17'},
+        {mode: 'slow'},
+      ],
+    });
+    assert.ok(m.rows.length <= 6);
+    assert.ok(m.rows.some(r => r.os === 'windows'));
+    assert.ok(m.rows.some(r => r.os === 'mac'));
+    assert.ok(m.rows.some(r => r.jdk === '8'));
+    assert.ok(m.rows.some(r => r.jdk === '17'));
+    assert.ok(m.rows.some(r => r.mode === 'slow'));
+  });
+
+  it('is independent of requirement order', () => {
+    const reqs = [
+      {os: 'windows'}, {os: 'mac'}, {os: 'linux'},
+      {jdk: '8'}, {jdk: '11'}, {jdk: '17'},
+      {mode: 'fast'}, {mode: 'slow'},
+    ];
+    const covered = m => ({
+      os: new Set(m.rows.map(r => r.os)),
+      jdk: new Set(m.rows.map(r => r.jdk)),
+      mode: new Set(m.rows.map(r => r.mode)),
+    });
+
+    const a = buildSimpleMatrix(createTestRng(7));
+    a.generateRows(8, {require: reqs});
+    const b = buildSimpleMatrix(createTestRng(7));
+    b.generateRows(8, {require: reqs.slice().reverse()});
+
+    // Both orders must cover all the required values (order does not drop any).
+    for (const m of [a, b]) {
+      const c = covered(m);
+      assert.deepEqual(c.os, new Set(['linux', 'windows', 'mac']));
+      assert.deepEqual(c.jdk, new Set(['8', '11', '17']));
+      assert.deepEqual(c.mode, new Set(['fast', 'slow']));
+    }
+  });
+
+  it('packs broad requirements into the floor number of rows', () => {
+    // os and jdk each have 3 values, mode has 2. A single row cannot hold two
+    // values of the same axis, so the floor is 3 rows: they can still carry
+    // os={linux,windows,mac}, jdk={8,11,17} and mode={fast,slow} together.
+    // With maxRows == floor there is no leftover budget for a coverage fill,
+    // so this asserts the packing alone fits everything.
+    const m = buildSimpleMatrix(createTestRng());
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = message => warnings.push(message);
+    try {
+      m.generateRows(3, {
+        require: [...m.allAxisValues('os'), ...m.allAxisValues('jdk'), ...m.allAxisValues('mode')],
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.deepEqual(warnings, [], `requirements should fit into 3 rows: ${warnings}`);
+    assert.equal(m.rows.length, 3);
+    assert.deepEqual(new Set(m.rows.map(r => r.os)), new Set(['linux', 'windows', 'mac']));
+    assert.deepEqual(new Set(m.rows.map(r => r.jdk)), new Set(['8', '11', '17']));
+    assert.deepEqual(new Set(m.rows.map(r => r.mode)), new Set(['fast', 'slow']));
+  });
+
+  it('fires tag(row) on the row that satisfies a requirement', () => {
+    const m = buildSimpleMatrix(createTestRng());
+    let tagged = null;
+    m.generateRows(6, {
+      require: [
+        {filter: {os: 'windows', jdk: '17', mode: 'slow'}, tag: r => { tagged = r; }},
+        {os: 'linux'},
+      ],
+    });
+    assert.ok(tagged, 'tag should have fired');
+    assert.equal(tagged.os, 'windows');
+    assert.equal(tagged.jdk, '17');
+    assert.equal(tagged.mode, 'slow');
+    assert.ok(m.rows.includes(tagged), 'tagged row must be part of the matrix');
+  });
+
+  it('counts a pinned generateRow() toward the budget and requirements', () => {
+    const m = buildSimpleMatrix(createTestRng());
+    const pinned = m.generateRow({os: 'windows', jdk: '17', mode: 'slow'});
+    pinned.collectCoverage = true;
+    m.generateRows(6, {require: [{os: 'windows'}, {mode: 'slow'}]});
+
+    // The pin already satisfies {os: windows} and {mode: slow}, so no extra row
+    // is spent on them, and the pin keeps its custom field.
+    const flagged = m.rows.filter(r => r.collectCoverage);
+    assert.equal(flagged.length, 1);
+    assert.equal(flagged[0], pinned);
+  });
+
+  it('warns when requirements do not fit the budget', () => {
+    const m = buildSimpleMatrix(createTestRng());
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = message => warnings.push(message);
+    try {
+      // os needs 3 distinct rows, but only 2 are allowed.
+      m.generateRows(2, {require: m.allAxisValues('os')});
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.equal(m.rows.length, 2);
+    assert.ok(warnings.some(w => /did not fit/.test(w)), `unexpected warnings: ${warnings}`);
+  });
+
+  it('throws on unsatisfiable requirements when failOnUnsatisfiableFilters is set', () => {
+    const m = buildSimpleMatrix(createTestRng());
+    m.exclude({os: 'windows'});
+    m.failOnUnsatisfiableFilters(true);
+    assert.throws(() => m.generateRows(5, {require: [{os: 'windows'}]}), /unsatisfiable/);
+  });
+});
+
 describe('summary', () => {
   it('counts good and bad combinations', () => {
     const m = buildSimpleMatrix(createTestRng());


### PR DESCRIPTION
## Why

`generateRow(...)` forces one row at a time, so both the job count and the pairwise coverage depend on the order of the calls: an early row that happens to match a later filter satisfies it by chance. On the pgjdbc matrix the same set of requirements produces anywhere from **5 to 9 jobs** and **41–49% pair coverage** purely as a function of seed and call order. There is also no clean way to pin one specific job (e.g. the single job that collects code coverage) and keep a handle to it inside the generated set.

## What

`generateRows(n, {require: [...]})` takes the requirements as a batch:

- guarantees a row for each requirement, subject to feasibility and the `n`-row budget;
- anchors each row on the most specific open requirement and packs the broad ones onto it via a coverage bonus, then spends the remaining budget on plain pairwise coverage;
- produces exactly `n` jobs, independent of the order of the list.

A `require` entry is either a filter or a `{filter, tag}` pair. `tag(row)` fires with the row that satisfies it, so a specific job can be marked (e.g. `row.collectCoverage = true`) without a second pass over the result. A pinned `generateRow(...)` row counts toward both the budget and requirement satisfaction. `allAxisValues(axis)` is the batch form of `ensureAllAxisValuesCovered`.

Internals: the candidate scoring and commit logic moved into `_addBestRow`, shared by `generateRow` and the batch path. `generateRow` behaviour is unchanged, and `generateRows` stays backward compatible with the legacy `(maxRows, filter)` signature.

Measured on the pgjdbc matrix, batch mode with a pinned coverage job, 10 seeds per budget:

| jobs | job count | pair %, avg (min–max) | weight %, avg (min–max) |
|---|---|---|---|
| 5 | exactly 5 | 41.1 (40.3–42.0) | 71.2 (70.6–72.2) |
| 6 | exactly 6 | 45.6 (45.1–46.3) | 75.9 (75.5–76.4) |
| 7 | exactly 7 | 49.9 (49.4–50.5) | 79.7 (79.1–80.1) |

The job count is now fixed and the per-seed spread drops to about ±0.5 pp, against 5–9 jobs and a 41–49% swing before.

## How to verify

- `npm test` — 39 tests pass, 7 new under *generateRows with batch requirements* (satisfies-each-requirement, order independence, packing to the floor, `tag` firing, pinned-row counting, over-budget warning, unsatisfiable-throws).
- README gains a *Batch requirements* section with the coverage-job example.

No consumer is migrated in this PR; the pgjdbc `matrix.mjs` change is a separate follow-up.